### PR TITLE
Added default colors for Extra Utilities Greenscreen (Lapis Caelestis)

### DIFF
--- a/src/main/java/com/falsepattern/rple/internal/RPLEDefaultValues.java
+++ b/src/main/java/com/falsepattern/rple/internal/RPLEDefaultValues.java
@@ -215,6 +215,23 @@ public final class RPLEDefaultValues {
         registry.colorizeBlock("ExtraUtilities:color_redstoneLight:14").brightness(RED).apply();
         registry.colorizeBlock("ExtraUtilities:color_redstoneLight:15").brightness(BLACK).apply();
 
+        registry.colorizeBlock("ExtraUtilities:greenscreen:0").brightness(WHITE).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:1").brightness(ORANGE).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:2").brightness(MAGENTA).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:3").brightness(LIGHT_BLUE).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:4").brightness(YELLOW).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:5").brightness(LIME).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:6").brightness(PINK).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:7").brightness(GRAY).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:8").brightness(LIGHT_GRAY).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:9").brightness(CYAN).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:10").brightness(PURPLE).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:11").brightness(BLUE).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:12").brightness(BROWN).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:13").brightness(GREEN).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:14").brightness(RED).apply();
+        registry.colorizeBlock("ExtraUtilities:greenscreen:15").brightness(BLACK).apply();
+
         registry.colorizeBlock("ExtraUtilities:chandelier").brightness(0xFEB).apply();
         registry.colorizeBlock("ExtraUtilities:magnumTorch").brightness(0xFEB).apply();
 


### PR DESCRIPTION
I added default colors for the Extra Utilities Greenscreen block (called Lapis Caelestis in-game).

Extra Utilities by itself provides varying light levels depending on which color is used. This can be seen in the code, where it uses an array which stores a tuple of values from 0.0 - 1.0, then combines them to form a light level (screenshot taken from Recaf):
<img width="1408" height="416" alt="image" src="https://github.com/user-attachments/assets/ed1698d5-ce7b-4adc-9c56-e861ec22963d" />

If we interpret the three values respectively as R, G and B, multiply them with `255` and convert them to hexadecimal, we get the following values (where `cols2` is the `BlockGreenScreen#cols` array converted to appropriate JS syntax):
<img width="455" height="626" alt="image" src="https://github.com/user-attachments/assets/d3546cab-000b-4ba3-9937-b021db8525a4" />
...which produce the following colors, in order:
<img width="1103" height="60" alt="image" src="https://github.com/user-attachments/assets/96d9ad9f-e798-402c-be19-2d98d9cb98c7" />

Here's the difference after adding the default colors:
<details><summary>Before</summary>
<img width="1280" height="768" alt="2026-06-16_07 03 56" src="https://github.com/user-attachments/assets/c9846eaf-eeb7-4958-98a3-99d2dfe5702a" /></details>

<details><summary>After</summary>
<img width="1280" height="768" alt="2026-06-16_07 35 19" src="https://github.com/user-attachments/assets/4e998deb-aded-48b1-a2c3-c186ace035a0" /></details>

Now, since some of these glow pretty brightly compared to before, I'm not sure if some people would rather prefer the original brightness values (regardless of the color). I suppose it doesn't really matter, because they can always overwrite the default colors with their own `custom_colors.json` file. Just something to consider I guess.